### PR TITLE
fix inconsistent selection of master

### DIFF
--- a/inventory/group_vars/all/k8s.yml
+++ b/inventory/group_vars/all/k8s.yml
@@ -1,6 +1,8 @@
 ---
 k8s_advertise_address_int: "{{ rpi_wired_int }}"
 
+k8s_master_group: rpi_k8s_master
+
 k8s_cluster_group: rpi_k8s
 
 k8s_cluster_init_skip_ca_verification: true

--- a/playbooks/deployments.yml
+++ b/playbooks/deployments.yml
@@ -2,7 +2,7 @@
 - hosts: rpi_k8s
   vars:
     k8s_admin_config: /etc/kubernetes/admin.conf
-    k8s_master: "{{ groups[k8s_cluster_group][0] }}"
+    k8s_master: "{{ groups[k8s_master_group][0] }}"
   tasks:
     - name: Ensuring {{ lookup('env','HOME') }}/.kube Exists
       file:

--- a/roles/ansible-k8s/defaults/main.yml
+++ b/roles/ansible-k8s/defaults/main.yml
@@ -8,7 +8,9 @@ k8s_advertise_address_int: enp0s8
 
 k8s_advertise_bind_port: 6443
 
-k8s_cluster_group: k8s
+k8s_master_group: rpi_k8s_master
+
+k8s_cluster_group: rpi_k8s
 
 k8s_cluster_init_skip_ca_verification: false
 

--- a/roles/ansible-k8s/tasks/set_facts.yml
+++ b/roles/ansible-k8s/tasks/set_facts.yml
@@ -1,7 +1,7 @@
 ---
 - name: set_facts | Setting K8s Master
   set_fact:
-    k8s_master: "{{ groups[k8s_cluster_group][0] }}"
+    k8s_master: "{{ groups[k8s_master_group][0] }}"
   tags:
     - k8s_get_dashboard
 


### PR DESCRIPTION
As per https://github.com/mrlesmithjr/ansible-rpi-k8s-cluster/issues/10#issuecomment-399622574, since Python lists aren't ordered the logic for selecting the k8s master node from the group list was non-deterministic. This change selects it from the master group, not the rpi_k8s group, so it should always select the correct machine.